### PR TITLE
Add managed-variable twenty questions demo

### DIFF
--- a/2026-05-pycon-italy/README.md
+++ b/2026-05-pycon-italy/README.md
@@ -96,4 +96,4 @@ uv run python twenty_questions_temporal_mv.py
   prompt is already performing well — try running more games with a deliberately
   weak prompt first, or adjust the optimizer settings.
 
-Both of these are waiting on a prod deployment as of 05/30 to resolve.
+Both of these are waiting on the next prod deployment as of 05/30 to resolve.

--- a/2026-05-pycon-italy/README.md
+++ b/2026-05-pycon-italy/README.md
@@ -5,3 +5,95 @@ Bologna, 2026-04-29
 * [Talk schedule](https://2026.pycon.it/en/keynotes/duable-agents-long-running-ai-workflows-in-a-flakey-world)
 * [Deck PDF](deck-v1.pdf)
 * [Pydantic AI + temporal docs](https://pydantic.dev/docs/ai/integrations/durable_execution/temporal/)
+
+---
+
+## `twenty_questions_temporal_mv.py` — Managed Variable Demo
+
+This variant of the 20 Questions demo drives the questioner's system prompt from
+a [Logfire Managed Variable](https://logfire.pydantic.dev/docs/guides/managed-variables/)
+so the prompt can be optimized live via the Logfire Prompt Optimizer without
+restarting the process.
+
+### Prerequisites
+
+* [Temporal CLI](https://docs.temporal.io/cli) installed (`brew install temporal`)
+* A Logfire project (local dev server or cloud) with a **write token** (`pylf_v2_…`)
+* `uv` for running the project
+
+### Environment variables
+
+Create a `.env` file (or export these in your shell):
+
+```
+# Logfire write token — used for both trace export and the variables REST API
+LOGFIRE_TOKEN=pylf_v1_local_…        # v1 token (trace export)
+LOGFIRE_API_KEY=pylf_v2_local_…      # v2 token (variables API + trace export)
+
+# Point at your Logfire instance (omit for cloud)
+LOGFIRE_BASE_URL=http://localhost:3000
+
+# LLM credentials (example uses MiniMax Anthropic-compatible endpoint)
+ANTHROPIC_API_KEY=…
+ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+```
+
+`LOGFIRE_TOKEN` and `LOGFIRE_API_KEY` can be the same v2 token — the code maps
+`LOGFIRE_TOKEN` → `LOGFIRE_API_KEY` automatically if only one is set.
+
+### First-time setup: seed the managed variable
+
+Before the first run you need to register the variable definition with Logfire
+and add an initial prompt version:
+
+**1. Push the variable schema**
+
+```bash
+uv run python -c "
+import os, logfire
+logfire.configure(variables=logfire.VariablesOptions())
+from twenty_questions_temporal_mv import _questioner_var
+logfire.variables_push(yes=True)
+print('Variable pushed.')
+"
+```
+
+This creates the variable in Logfire (name, schema, description). You only need
+to do this once, or whenever the variable definition changes.
+
+**2. Set the initial value in Logfire**
+
+Open your Logfire project → **Managed Variables** tab, find
+`questioner_prompt_twenty_questions_temporal`, and add a version with the prompt
+text you want to use as the starting point.
+
+### Running the demo
+
+Start Temporal, then run the game:
+
+```bash
+temporal server start-dev --headless &
+uv run python twenty_questions_temporal_mv.py
+```
+
+### Using the Prompt Optimizer
+
+1. Run several games to accumulate spans in Logfire.
+2. In the Logfire UI open your project → **Managed Variables** →
+   `questioner_prompt_twenty_questions_temporal`.
+3. Click **Optimize** → **Generate Proposal**.
+4. Review the proposed prompt changes and publish a new version.
+5. The next game run will automatically pick up the new version — no restart
+   needed.
+
+#### Known issues with the Prompt Optimizer
+
+* **Large span count**: The optimizer may throw an error if there are a very
+  large number of spans associated with the variable. If this happens, reduce
+  the time window or number of runs before generating a proposal.
+* **"Nothing to optimize"**: The optimizer may reject a proposal if it doesn't
+  detect a meaningful improvement opportunity. This is expected when the current
+  prompt is already performing well — try running more games with a deliberately
+  weak prompt first, or adjust the optimizer settings.
+
+Both of these are waiting on a prod deployment as of 05/30 to resolve.

--- a/2026-05-pycon-italy/deck/deck.mdx
+++ b/2026-05-pycon-italy/deck/deck.mdx
@@ -313,7 +313,7 @@ durable_conference_talk_agent = TemporalAgent(conference_talk_agent)
 
 # Agents <span style={{ color: 'var(--accent)' }}>Optimization</span>
 
-## Improve Long Running Agent performance with LLM traces
+## Improve Long Running Agent performance with traces
 
 </div>
 

--- a/2026-05-pycon-italy/twenty_questions_temporal_mv.py
+++ b/2026-05-pycon-italy/twenty_questions_temporal_mv.py
@@ -1,0 +1,209 @@
+"""twenty_questions_temporal_mv.py
+
+Same as twenty_questions_temporal.py but the questioner agent's system prompt
+is driven by a Logfire managed variable so it can be optimized via the
+Logfire Prompt Optimizer.
+
+Key differences from the original:
+- logfire.configure() gets variables=VariablesOptions() for managed-variable support
+- LOGFIRE_TOKEN is mapped to LOGFIRE_API_KEY (same v2 token works for both)
+- The questioner system prompt is stored in a Logfire managed variable
+- play() resolves the variable with `with _questioner_var.get() as resolved:`
+  and passes the resolved value to the workflow, which forwards it to
+  TemporalAgent.run(..., instructions=...) for a clean per-run override
+
+Usage:
+    Set LOGFIRE_TOKEN (and optionally LOGFIRE_VAR_QUESTIONER_PROMPT) in your
+    environment, then run exactly as the original:
+
+        uv run python twenty_questions_temporal_mv.py
+        uv run python twenty_questions_temporal_mv.py <resume-workflow-id>
+"""
+
+import asyncio
+import os
+import sys
+import uuid
+from enum import StrEnum
+from random import random
+
+import logfire
+from pydantic_ai import Agent
+from pydantic_ai.durable_exec.temporal import (
+    AgentPlugin,
+    LogfirePlugin,
+    PydanticAIPlugin,
+    TemporalAgent,
+)
+from pydantic_ai.tools import RunContext
+from temporalio import workflow
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+# Logfire uses LOGFIRE_TOKEN for trace export and LOGFIRE_API_KEY for the
+# variables REST API. The same v2 token works for both — map it here so
+# VariablesOptions() can resolve variable values from the Logfire API.
+_logfire_token = os.environ.get('LOGFIRE_TOKEN')
+if _logfire_token:
+    os.environ.setdefault('LOGFIRE_API_KEY', _logfire_token)
+
+# Enable managed variables only when we have an API key to talk to Logfire.
+_variables_opts = logfire.VariablesOptions() if os.environ.get('LOGFIRE_API_KEY') else None
+
+logfire.configure(console=False, variables=_variables_opts)
+logfire.instrument_pydantic_ai()
+
+# ---------------------------------------------------------------------------
+# Secret & managed variable name
+# ---------------------------------------------------------------------------
+
+secret = 'potato'
+
+# The managed variable name can be overridden via env var so different
+# environments / demo runs can use different variable namespaces.
+QUESTIONER_VAR_NAME = os.environ.get(
+    'LOGFIRE_VAR_QUESTIONER_PROMPT',
+    'questioner_prompt_twenty_questions_temporal',
+)
+
+DEFAULT_QUESTIONER_INSTRUCTIONS = """
+You are playing a question and answer game. You need to guess what object the other player is thinking of.
+Your job is to ask yes/no questions to narrow down the possibilities.
+
+Start with broad questions (e.g., "Is it alive?", "Is it bigger than a breadbox?") and get more specific.
+When you're confident, make a guess by saying "Is it [specific object]?"
+
+You should ask strategic questions based on the previous answers.
+"""
+
+# Module-level handle — created once; the value is resolved lazily via .get()
+# each time play() is called. This allows prompt changes to take effect without
+# restarting the process.
+#
+# Guard against double-registration: Temporal's workflow sandbox re-imports this
+# module in the same process (sharing the global logfire state), which would
+# cause logfire.var() to raise "already registered". Retrieve the existing
+# handle instead.
+try:
+    _questioner_var = logfire.var(
+        QUESTIONER_VAR_NAME,
+        default=DEFAULT_QUESTIONER_INSTRUCTIONS,
+        description='System prompt for the 20 Questions questioner agent.',
+    )
+except ValueError:
+    _questioner_var = next(v for v in logfire.variables_get() if v.name == QUESTIONER_VAR_NAME)
+
+# ---------------------------------------------------------------------------
+# Answerer agent — unchanged from the original
+# ---------------------------------------------------------------------------
+
+
+class Answer(StrEnum):
+    yes = 'yes'
+    kind_of = 'kind of'
+    not_really = 'not really'
+    no = 'no'
+    complete_wrong = 'complete wrong'
+
+
+answerer_agent = Agent(
+    'anthropic:claude-haiku-4-5',
+    instructions=f"""
+You are playing a question and answer game.
+Your job is to answer questions about a secret object only you know truthfully.
+
+THE SECRET OBJECT IS: {secret}.
+""",
+    output_type=Answer,
+    name='answerer_agent',
+)
+temporal_answerer_agent = TemporalAgent(answerer_agent)
+
+# ---------------------------------------------------------------------------
+# Questioner agent — module-level TemporalAgent with default instructions.
+# The actual instructions are passed per-run via TemporalAgent.run(instructions=)
+# so they can be overridden with the resolved managed-variable value at runtime.
+# ---------------------------------------------------------------------------
+
+questioner_agent = Agent(
+    'anthropic:claude-sonnet-4-5',
+    # No default instructions here — the system prompt comes entirely from the
+    # managed variable value, passed per-run via TemporalAgent.run(instructions=)
+    name='questioner_agent',
+)
+
+
+@questioner_agent.tool
+async def ask_question(ctx: RunContext, question: str) -> Answer:
+    if random() > 0.9:
+        raise RuntimeError('broken')
+    print(f'{ctx.run_step:>2}: {question}:', end=' ', flush=True)
+    result = await temporal_answerer_agent.run(question)
+    print(result.output)
+    return result.output
+
+
+temporal_questioner_agent = TemporalAgent(questioner_agent)
+
+# ---------------------------------------------------------------------------
+# Temporal workflow
+# ---------------------------------------------------------------------------
+
+
+@workflow.defn
+class TwentyQuestionsWorkflow:
+    @workflow.run
+    async def run(self, questioner_prompt: str) -> None:
+        """Run one full game.
+
+        *questioner_prompt* is the resolved managed-variable value, forwarded
+        here from play() so the workflow doesn't need to do any I/O itself.
+        TemporalAgent.run(instructions=...) overrides the agent's instructions
+        for this specific run without touching module-level state.
+        """
+        result = await temporal_questioner_agent.run('start', instructions=questioner_prompt)
+        print(f'After {len(result.all_messages()) / 2}, the answer is: {result.output}')
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def play(resume_id: str | None) -> None:
+    client = await Client.connect('localhost:7233', plugins=[PydanticAIPlugin(), LogfirePlugin()])
+
+    async with Worker(
+        client,
+        task_queue='twenty_questions',
+        workflows=[TwentyQuestionsWorkflow],
+        plugins=[
+            AgentPlugin(temporal_answerer_agent),
+            AgentPlugin(temporal_questioner_agent),
+        ],
+    ):
+        # Resolve the managed variable and wrap the entire workflow execution
+        # inside the context manager. This records which variable version (and
+        # therefore which prompt) was used, enabling the Logfire Optimizer to
+        # correlate prompt versions with game outcomes.
+        with _questioner_var.get() as resolved:
+            if resume_id is not None:
+                print('resuming existing workflow', resume_id)
+                await client.get_workflow_handle(resume_id).result()
+            else:
+                job_id = f'twenty_questions-{uuid.uuid4()}'
+                print(f'{job_id=}')
+                await client.execute_workflow(
+                    TwentyQuestionsWorkflow.run,
+                    resolved.value,  # pass managed-var value as workflow input
+                    id=job_id,
+                    task_queue='twenty_questions',
+                )
+
+
+if __name__ == '__main__':
+    try:
+        asyncio.run(play(sys.argv[1] if len(sys.argv) > 1 else None))
+    except KeyboardInterrupt:
+        print('Exiting...')
+        sys.exit(1)


### PR DESCRIPTION
Adds `twenty_questions_temporal_mv.py` — a variant of the temporal twenty questions demo that uses Logfire managed variables to control the questioner's system prompt at runtime, enabling live prompt optimization during the PyCon Italia talk.

### Changes
- **`twenty_questions_temporal_mv.py`** (new): Full Temporal + pydantic-ai + Logfire managed variable integration. Reads the questioner prompt from a Logfire variable (`questioner_prompt_twenty_questions_temporal`), resolves it at workflow start, and passes it as workflow input so the prompt can be swapped via the Logfire UI without redeployment.
- **`README.md`**: Setup instructions for env vars, first-time variable seeding (`logfire.variables_push`), run command, and known optimizer edge cases.
- **`deck/deck.mdx`**: Minor wording tweak (conflict resolved against merged main).